### PR TITLE
add: rustack.Disk.ExternalID attribute

### DIFF
--- a/rustack/disk.go
+++ b/rustack/disk.go
@@ -10,6 +10,7 @@ type Disk struct {
 	ID             string          `json:"id"`
 	Name           string          `json:"name"`
 	Scsi           string          `json:"scsi"`
+	ExternalID     string          `json:"external_id"`
 	Size           int             `json:"size"`
 	Vm             *Vm             `json:"vm"`
 	StorageProfile *StorageProfile `json:"storage_profile"`


### PR DESCRIPTION
This attribute is helpful to associate block device on a virtual server with a disk on the Rustack Cloud Platform